### PR TITLE
INT-1013: Add `build:dev` script for development builds

### DIFF
--- a/public-api/package.json
+++ b/public-api/package.json
@@ -17,6 +17,7 @@
   ],
   "scripts": {
     "build": "vite build",
+    "build:dev": "vite build --mode development --minify false",
     "publish-local": "npm publish --registry http://localhost:4873"
   }
 }

--- a/state-driver/package.json
+++ b/state-driver/package.json
@@ -17,9 +17,13 @@
   ],
   "scripts": {
     "build": "vite build",
+    "build:dev": "vite build --mode development --minify false",
     "publish-local": "npm publish --registry http://localhost:4873"
   },
   "dependencies": {
     "effector": "^23.3.0"
+  },
+  "devDependencies": {
+    "vite-tsconfig-paths": "^5.1.4"
   }
 }


### PR DESCRIPTION
INT-1013: Update dependencies in state-driver package and add build:dev script

- Added `vite-tsconfig-paths` as a devDependency
- Introduced `build:dev` script to enable non-minified development builds across packages.