### PR TITLE
INT-1013: Add vite as devDependency in public-api and state-driver

### DIFF
--- a/public-api/package.json
+++ b/public-api/package.json
@@ -19,5 +19,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development --minify false",
     "publish-local": "npm publish --registry http://localhost:4873"
+  },
+  "devDependencies": {
+    "vite": "^5.0.8"
   }
 }

--- a/state-driver/package.json
+++ b/state-driver/package.json
@@ -24,6 +24,7 @@
     "effector": "^23.3.0"
   },
   "devDependencies": {
+    "vite": "^5.0.8",
     "vite-tsconfig-paths": "^5.1.4"
   }
 }


### PR DESCRIPTION
- Included `vite` version `^5.0.8` as a devDependency in both packages.